### PR TITLE
stop using os.tmpDir() and use os.tmpdir() ?

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -22,7 +22,7 @@ exports.trimImages = function (files, options, callback) {
 	async.eachSeries(files, function (file, next) {
 		file.originalPath = file.path;
 		i++;
-		file.path = path.join(os.tmpDir(), 'spritesheet_js_' + (new Date()).getTime() + '_image_' + i + '.png');
+		file.path = path.join(os.tmpdir(), 'spritesheet_js_' + (new Date()).getTime() + '_image_' + i + '.png');
 
 		var scale = options.scale && (options.scale !== '100%') ? ' -resize ' + options.scale : '';
 		var fuzz = options.fuzz ? ' -fuzz ' + options.fuzz : '';
@@ -49,7 +49,7 @@ exports.resizeImages = function (files, options, callback) {
 			if (!file.originalPath) {
 				file.originalPath = file.path;
 			}
-			file.path = path.join(os.tmpDir(), 'spritesheet_js_' + (new Date()).getTime() + '_image_' + i + '.png');
+			file.path = path.join(os.tmpdir(), 'spritesheet_js_' + (new Date()).getTime() + '_image_' + i + '.png');
 			// Build the resize command, we want one of the following
 			// - convert {src} -resize {width}\! {dest}             Only width specified
 			// - convert {src} -resize x{height}\! {dest}           Only height specified
@@ -208,7 +208,7 @@ exports.generateImage = function (files, options, callback) {
 	if (!options.padding) options.padding = 0;
 	if (!options.gutter) options.gutter = 0;
 	var outputPath = options.path + '/' + options.name + '.png';
-	
+
 	var content = { x:0,y:0, w:0,h:0 };
 	var command = [];
 	var extraSize = String('"' + outputPath + '"').length + 1;
@@ -221,7 +221,7 @@ exports.generateImage = function (files, options, callback) {
 	// Larger numbers = better performance, but less safe.
 	// Ideally you want to use about half the maximum system allowance,
 	// to be on the safe side.
-	var MAX_COMMAND_SIZE = 8000; 
+	var MAX_COMMAND_SIZE = 8000;
 
 	function addOperation( op ){
 		command.push(op);
@@ -232,7 +232,7 @@ exports.generateImage = function (files, options, callback) {
 	async.eachSeries(files, function (file, callbackAsync) {
 		content.x = file.x + options.padding + options.gutter;
 		content.y = file.y + options.padding + options.gutter;
-		
+
 		if (options.gutter) {
 			content.w = file.width - options.padding*2 - options.gutter*2;
 			content.h = file.height - options.padding*2 - options.gutter*2;


### PR DESCRIPTION
Hi.

`os.tmpDir()` is deprecated.
https://nodejs.org/api/deprecations.html#deprecations_dep0022_os_tmpdir

I want to use `os.tmpdir()`.
